### PR TITLE
Add support for beamlines with custom root folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,5 +132,6 @@ dmypy.json
 # Local settings
 settings.json
 
+.idea/
 .idea/dataSources.xml
 /workspace.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 settings.json
 
 .idea/dataSources.xml
+/workspace.code-workspace

--- a/api/proposal_api.py
+++ b/api/proposal_api.py
@@ -122,7 +122,7 @@ async def get_proposal_directories(proposal_id: ProposalIn = Depends(), testing:
     projection = {"_id": 0.0, "last_updated": 0.0}
     proposal_doc = collection.find_one(query, projection=projection)
 
-    proposal_doc.setdefault('cycles', [""])
+    proposal_doc.setdefault('cycles', [])
 
     if proposal_doc is None:
         return {'error_message': f"No proposal {str(proposal_id.proposal_id)} found."}

--- a/api/proposal_api.py
+++ b/api/proposal_api.py
@@ -10,6 +10,7 @@ from fastapi.security import APIKeyHeader
 from pymongo import MongoClient
 
 from infrastucture import settings
+from infrastucture.database import fetch_beamline_root_directory_name
 from models.proposal import ProposalIn, ProposalUpdate
 from models.facility import Cycle
 from api.facility_api import facility_data
@@ -157,6 +158,7 @@ async def get_proposal_directories(proposal_id: ProposalIn = Depends(), testing:
     for beamline in beamlines:
         for cycle in cycles:
             beamline_tla = str(beamline).lower()
+            beamline_dir = await fetch_beamline_root_directory_name(beamline_tla.upper())
             users_acl: list[dict[str, str]] = []
             groups_acl: list[dict[str, str]]  = []
 
@@ -166,7 +168,7 @@ async def get_proposal_directories(proposal_id: ProposalIn = Depends(), testing:
             groups_acl.append({'n2sn-right-dataadmin': "rw"})
             groups_acl.append({f"n2sn-right-dataadmin-{beamline_tla}": "rw"})
 
-            directory = {'path': root / beamline_tla / 'proposals' / str(cycle) / str(data_session),
+            directory = {'path': root / beamline_dir / 'proposals' / str(cycle) / str(data_session),
                          'owner': 'nsls2data', 'group': str(data_session), 'group_writable' : True,
                          'users': users_acl, 'groups': groups_acl}
             directories.append(directory)

--- a/api/users_api.py
+++ b/api/users_api.py
@@ -16,7 +16,6 @@ from N2SNUserTools.ldap import ADObjects
 from infrastucture import settings
 
 client = MongoClient(settings.NSLS2CORE_MONGODB_URI)
-#client = MongoClient(settings.NSLS2CORE_LOCAL_TESTING_URI)
 
 router = fastapi.APIRouter()
 

--- a/infrastucture/database.py
+++ b/infrastucture/database.py
@@ -17,3 +17,24 @@ async def fetch_all_beamlines():
         pprint.pprint(doc)
         instruments.append(Instrument(**doc))
     return instruments
+
+async def fetch_beamline_root_directory_name(beamline_name : str):
+    database = client["nsls2core"]
+    collection = database["beamlines"]
+    query = {"name": beamline_name.upper()}
+    projection = {"_id": 0.0, "last_updated": 0.0}
+    beamline_doc = collection.find_one(query, projection=projection)
+
+    if beamline_doc is None:
+        return {'error_message': f"No beamline {beamline_name.upper()} exists."}
+
+    try:
+        custom_rootdir = beamline_doc['custom_root_directory']
+    except KeyError:
+        # If the custom root directory field does not exist, just use the TLA
+        return str(beamline_name.lower())
+
+    if custom_rootdir:
+        return str(custom_rootdir).lower()
+    else:
+        return str(beamline_name.lower())


### PR DESCRIPTION
For certain beamlines we are now required to support cases where the top level beamline directory is not the same as the beamline name. 

If there is a `custom_root_directory` defined in the database, then the `/proposal/{proposal_id}/directories` api will return the correct values.

