### PR TITLE
Revert "Move into /v1 namespace."

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,11 +38,11 @@ async def add_server_timing_header(request: Request, call_next):
 
 def configure_routing():
     api.mount('/static', StaticFiles(directory='static'), name='static')
-    api.include_router(home.router, prefix="/v1")
-    api.include_router(instrument_api.router, prefix="/v1")
-    api.include_router(facility_api.router, prefix="/v1")
-    api.include_router(proposal_api.router, prefix="/v1")
-    api.include_router(users_api.router, prefix="/v1")
+    api.include_router(home.router)
+    api.include_router(instrument_api.router)
+    api.include_router(facility_api.router)
+    api.include_router(proposal_api.router)
+    api.include_router(users_api.router)
 
 def configure():
     configure_routing()


### PR DESCRIPTION
We plan to deploy the fixes now, and the `/` -> `/v1/` scope change later.

This reverts commit 0bdd42d69db5cd12188acf033762d5e64c20d05e.