### PR TITLE
add NYX to the list of SynchWeb beamlines

### DIFF
--- a/api/proposal_api.py
+++ b/api/proposal_api.py
@@ -26,7 +26,7 @@ WORKFLOW_USERS = {
     "sst1": "workflow-sst",
     "sst2": "workflow-sst",
 }
-SYNCHWEB_BEAMLINES = {"amx", "fmx", "lix"}
+SYNCHWEB_BEAMLINES = {"amx", "fmx", "lix", "nyx"}
 
 # Handle special cases where the softioc user is *not* softioc-{beamline_tla}
 IOC_USERS = {


### PR DESCRIPTION
This change is required for any files in NYX-associated proposals to be visible from within the SynchWeb application.